### PR TITLE
fix ssl path

### DIFF
--- a/setupProxy.sh
+++ b/setupProxy.sh
@@ -27,8 +27,8 @@ server {
         listen $port ssl;
         listen [::]:$port ssl;
 
-        ssl_certificate /usr/local/bin/mtc-jsonrpc/ssl.crt;
-        ssl_certificate_key /usr/local/bin/mtc-jsonrpc/ssl.key;
+        ssl_certificate ~/.local/share/mtc-jsonrpc/ssl.crt;
+        ssl_certificate_key ~/.local/share/mtc-jsonrpc/ssl.key;
 
         allow $ip;
         deny all;


### PR DESCRIPTION
Except for the port issue.
When I start the server, it shows a credential entry error.
https://github.com/igroman787/mtc-jsonrpc/blob/1c501a0e106dcc671f0e11ed509f5bbc4535274c/setupProxy.sh#L30-L31
In fact, the credential path generated by mytonctrl will be
````
         ssl_certificate ~/.local/share/mtc-jsonrpc/ssl.crt;
         ssl_certificate_key ~/.local/share/mtc-jsonrpc/ssl.key;
````