### PR TITLE
fix port

### DIFF
--- a/mtc-jsonrpc.py
+++ b/mtc-jsonrpc.py
@@ -553,7 +553,7 @@ def Init():
 
 	hostip = "127.0.0.1"
 
-	run_simple(hostip, port-1, application)
+	run_simple(hostip, port, application)
 #end define
 
 


### PR DESCRIPTION
I tested the new mtc-jsonrpc
I found that there is something wrong with the port numbers.
For example, my port is displayed as 4724 in the terminal, but the port actually opened is 4723.
It should be the problem here.

https://github.com/igroman787/mtc-jsonrpc/blob/1c501a0e106dcc671f0e11ed509f5bbc4535274c/mtc-jsonrpc.py#L556